### PR TITLE
commit the sleep quality per week function

### DIFF
--- a/src/sleepDataFunctions.js
+++ b/src/sleepDataFunctions.js
@@ -35,7 +35,7 @@ function getAverageSleepHours(user, sleepArray) {
     const userSleepData = sleepArray.filter((entry) => entry.userID === user.id);
     const start = new Date(startDate);
     const end = new Date(startDate);
-    end.setDate(start.getDate() + 6); // End date is 6 days after start date
+    end.setDate(start.getDate() + 6);
   
     const sleepDataForWeek = userSleepData.filter((entry) => {
       const entryDate = new Date(entry.date);
@@ -48,6 +48,35 @@ function getAverageSleepHours(user, sleepArray) {
     }));
   }
 
+  function sleepQualityForWeek(user, sleepArray, startDate) {
+    const userSleepData = sleepArray.filter((entry) => entry.userID === user.id);
+    const start = new Date(startDate);
+    const end = new Date(startDate);
+    end.setDate(start.getDate() + 6);
+  
+    const sleepDataForWeek = userSleepData.filter((entry) => {
+      const entryDate = new Date(entry.date);
+      return entryDate >= start && entryDate <= end;
+    });
+  
+    // Create an empty array with all the dates within the week
+    const weekDates = [];
+    for (let i = 0; i < 7; i++) {
+      const date = new Date(start);
+      date.setDate(start.getDate() + i);
+      weekDates.push(date.toISOString().split('T')[0].replace(/-/g, '/'));
+    }
+  
+    // Map dates to the corresponding sleep quality or 0 if no data is present
+    return weekDates.map(date => {
+      const dayData = sleepDataForWeek.find(entry => entry.date === date);
+      return {
+        date,
+        sleepQuality: dayData ? dayData.sleepQuality : 0
+      };
+    });
+  }
+  
 
   function setSleepData(data) {
     newSleepData = data;
@@ -58,5 +87,6 @@ export {
     specificSleepHoursByDay,
     specificSleepQualityByDay,
     sleepHoursForWeek,
+    sleepQualityForWeek,
     setSleepData
   };

--- a/test/weekOfSleep-test.js
+++ b/test/weekOfSleep-test.js
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { sleepHoursForWeek } from "../src/sleepDataFunctions.js";
+import { sleepHoursForWeek, sleepQualityForWeek } from "../src/sleepDataFunctions.js";
 
 // Mock Data
 const usersArray = [
@@ -51,4 +51,51 @@ const usersArray = [
         const result = sleepHoursForWeek(user, sleepData, startDate);
         expect(result).to.deep.equal([]);
       });
-});
+
+      describe("sleepQualityForWeek", () => {
+        it("should return the sleep quality each day over the course of a given week for a user", () => {
+          const user = usersArray[0];
+          const startDate = "2023/03/20";
+          const result = sleepQualityForWeek(user, sleepData, startDate);
+          expect(result).to.deep.equal([
+            { date: "2023/03/20", sleepQuality: 4.3 },
+            { date: "2023/03/21", sleepQuality: 3.8 },
+            { date: "2023/03/22", sleepQuality: 4.1 },
+            { date: "2023/03/23", sleepQuality: 2.5 },
+            { date: "2023/03/24", sleepQuality: 3.0 },
+            { date: "2023/03/25", sleepQuality: 4.0 },
+            { date: "2023/03/26", sleepQuality: 4.1 }
+          ]);
+        });
+
+        it("should return an array with zeros if the sleep data array is empty", () => {
+          const user = usersArray[0]; // Trystan Gorczany
+          const startDate = "2023/03/20";
+          const result = sleepQualityForWeek(user, [], startDate);
+          expect(result).to.deep.equal([
+            { date: "2023/03/20", sleepQuality: 0 },
+            { date: "2023/03/21", sleepQuality: 0 },
+            { date: "2023/03/22", sleepQuality: 0 },
+            { date: "2023/03/23", sleepQuality: 0 },
+            { date: "2023/03/24", sleepQuality: 0 },
+            { date: "2023/03/25", sleepQuality: 0 },
+            { date: "2023/03/26", sleepQuality: 0 }
+          ]);
+        });
+    
+        it("should return an array with zeros if the user exists but has no sleep data entries for the specified week", () => {
+          const user = usersArray[0]; // Trystan Gorczany
+          const startDate = "2023/02/01";
+          const result = sleepQualityForWeek(user, sleepData, startDate);
+          expect(result).to.deep.equal([
+            { date: "2023/02/01", sleepQuality: 0 },
+            { date: "2023/02/02", sleepQuality: 0 },
+            { date: "2023/02/03", sleepQuality: 0 },
+            { date: "2023/02/04", sleepQuality: 0 },
+            { date: "2023/02/05", sleepQuality: 0 },
+            { date: "2023/02/06", sleepQuality: 0 },
+            { date: "2023/02/07", sleepQuality: 0 }
+          ]);
+        });
+      });
+    });


### PR DESCRIPTION
This pr will commit the function to get the user's sleep quality over a week. 
The sleepQualityForWeek function is designed to return the sleep quality for each day over the course of a given week for a specific user. If there is no sleep data for a specific day, it returns 0 for that day's sleep quality. It utilizes the date object to simulate a start and end date for a given week and it constructs an array of dates for the specified week. It then maps these dates to the corresponding sleep quality, assigning 0 if no data is found for a specific date.